### PR TITLE
Add support for the rds service

### DIFF
--- a/brokers.go
+++ b/brokers.go
@@ -13,7 +13,7 @@ type BrokerChecker interface {
 type AWSRDSChecker struct{}
 
 func (c AWSRDSChecker) IsCompatibleSource(service plugin_models.GetServices_Model) bool {
-	if service.Service.Name != "aws-rds" {
+	if service.Service.Name != "aws-rds" && service.Service.Name != "rds" {
 		return false
 	}
 	if strings.Contains(service.ServicePlan.Name, "mysql") {

--- a/resources/export.py
+++ b/resources/export.py
@@ -28,7 +28,7 @@ def find_s3_bucket_creds(vcap):
 def backup():
     if os.environ['VCAP_SERVICES']:
         vcap = json.loads(os.environ.get('VCAP_SERVICES'))
-        services = vcap['aws-rds']
+        services = vcap.get('aws-rds', []) + vcap.get('rds', [])
         for service in services:
             if service['name'] == os.environ.get('SOURCE_SERVICE'):
                 creds = service['credentials']

--- a/resources/import.py
+++ b/resources/import.py
@@ -28,7 +28,7 @@ def restore_psql(creds, store_stream_cmd):
 def import_data():
     if os.environ['VCAP_SERVICES']:
         vcap = json.loads(os.environ.get('VCAP_SERVICES'))
-        services = vcap['aws-rds']
+        services = vcap.get('aws-rds', []) + vcap.get('rds', [])
         for service in services:
             if service['name'] == os.environ.get('TARGET_SERVICE'):
                 creds = service['credentials']


### PR DESCRIPTION
Subset of @ccostino https://github.com/18F/cg-migrate-db/pull/13
This changeset adds support for the rds service in addition to the
aws-rds service found in the CF Marketplace. It also adds a couple of
additional checks to safeguard against a KeyError being raised if a
service is not found.
Closes #12 

Depends on #14 