### PR TITLE
Adds support for flags in the upload-backup-data command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,11 @@ upload automatically.
 
 **Usage:**
 ```sh
-cf upload-backup-data YourFilePathHere
+cf upload-backup-data -p <file_path> [-store <name_of_s3_service]
 ```
+
+*Note: Providing the optional `-store` flag will run this command in
+non-interactive mode.*
 
 ### `cf clean-export-config`
 **Cleans your config file and create a new one.**

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ upload automatically.
 
 **Usage:**
 ```sh
-cf upload-backup-data -p <file_path> [-store <name_of_s3_service]
+cf upload-backup-data -p <file_path> [-store <name_of_s3_service>]
 ```
 
 *Note: Providing the optional `-store` flag will run this command in


### PR DESCRIPTION
This changeset adds two flags to the `upload-backup-data` command:

* `-p` - Used to specify the file path to upload (required).
* `-store` - Used to specify the name of the S3 service to send the upload to.

Note that using the `-store` flag will cause the `upload-backup-data` command to run in a non-interactive mode and will not prompt the user to choose an S3 bucket to target.

h/t to @jcscottiii for all of the help and mentoring with Go!