### PR TITLE
Update Python support to 3.5.4

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func (p *ExportPlugin) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 0,
-			Build: 3,
+			Build: 4,
 		},
 		Commands: []plugin.Command{
 			{

--- a/resources/runtime.txt
+++ b/resources/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.5.4


### PR DESCRIPTION
This changeset updates the Python support to run the exported apps with the latest version of the Python 3.5 series.  The plugin stopped working when the latest `python_buildpack` was released for Cloud Foundry because support for 3.5.2 dropped.