### PR TITLE
[WIP] Update Python support to 3.5.5

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func (p *ExportPlugin) GetMetadata() plugin.PluginMetadata {
 		Version: plugin.VersionType{
 			Major: 0,
 			Minor: 0,
-			Build: 4,
+			Build: 5,
 		},
 		Commands: []plugin.Command{
 			{

--- a/resources/runtime.txt
+++ b/resources/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.4
+python-3.5.5


### PR DESCRIPTION
This (almost) updates Python support to run the exported apps with the latest version of the Python 3.5 series.

This commit includes the following:
- Update listed Python support to 3.5.5
- Update this plugin's version number

This commit does not include the following:
- Update bindata.go

Noticed this while on deadline for a project, so I'm opening a WIP pull request rather than building `bindata.go`, but AFAIK that's the only remaining step here.